### PR TITLE
Support self-extracting archives

### DIFF
--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -376,6 +376,8 @@ FileText2Mime = {
     "FLAC audio bitstream data": "audio/flac",
     "MS Windows HtmlHelp Data": "application/x-chm",
     "ZPAQ stream": "application/zpaq",
+    ".*RAR self-extracting archive": "application/x-rar",
+    ".*(?<!RAR )self-extracting archive": "application/x-7z-compressed",
 }
 
 def guess_mime_file_text (file_prog, filename):

--- a/patoolib/util.py
+++ b/patoolib/util.py
@@ -16,6 +16,7 @@
 """Utility functions."""
 from __future__ import print_function
 import os
+import re
 import sys
 import shutil
 import subprocess
@@ -387,7 +388,7 @@ def guess_mime_file_text (file_prog, filename):
         return None
     # match output against known strings
     for matcher, mime in FileText2Mime.items():
-        if output.startswith(matcher) and mime in ArchiveMimetypes:
+        if re.match(matcher, output) and mime in ArchiveMimetypes:
             return mime
     return None
 


### PR DESCRIPTION
In order to detect SFXs, we need to be able to search the output of `file` command not necessarily from the beginning. So we first address that. Then, we add relevant signatures to detect SFXs.