### PR TITLE
PM-5946: Auto rename when extracting from archive (files with the same name)

### DIFF
--- a/patoolib/programs/p7zip.py
+++ b/patoolib/programs/p7zip.py
@@ -20,7 +20,7 @@ def extract_7z(archive, compression, cmd, verbosity, interactive, outdir):
     cmdlist = [cmd, 'x']
     if not interactive:
         cmdlist.append('-y')
-    cmdlist.extend(['-o%s' % outdir, '--', archive])
+    cmdlist.extend(['-o%s' % outdir, '-aou', '--', archive])
     return cmdlist
 
 def extract_7z_singlefile(archive, compression, cmd, verbosity, interactive, outdir):

--- a/patoolib/programs/rar.py
+++ b/patoolib/programs/rar.py
@@ -18,7 +18,7 @@ import os
 
 def extract_rar (archive, compression, cmd, verbosity, interactive, outdir):
     """Extract a RAR archive."""
-    cmdlist = [cmd, '-kb', 'x']
+    cmdlist = [cmd, '-kb', '-or', 'x']
     if not interactive:
         cmdlist.extend(['-p-', '-y'])
     cmdlist.extend(['--', os.path.abspath(archive)])

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from distutils import util
 from distutils.file_util import write_file
 
 AppName = "patool"
-AppVersion = "1.13.8"
+AppVersion = "1.13.9"
 MyName = "Bastian Kleineidam"
 MyEmail = "bastian.kleineidam@web.de"
 


### PR DESCRIPTION
Modification of 7z & unrar command lines to rename files automatically (if a file with the same name already exists).
7z: `-aou`: aUto rename extracting file (for example, name.txt will be renamed to name_1.txt). 
unrar: `-or`: Rename extracted files automatically if file with the same name already exists. Renamed file will get the name like 'filename(N).txt', where 'filename.txt' is the original file name and 'N' is a number starting from 1 and incrementing if file exists.



